### PR TITLE
docs: suggest article to pdi

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ This is a simple document that aims to list and index evidences of personal deve
   <li>
     <details> 
       <summary>
+        <a href="https://alistair.cockburn.us/hexagonal-architecture/">[Article] Hexagonal Architecture</a> (0%) 
+      </summary>
+      <ul>
+        <li>
+          Started:
+        </li>
+        <li>
+          Finished:
+        </li>
+      </ul>
+    </details>
+  </li>
+  <li>
+    <details> 
+      <summary>
         <a href="https://github.com/gabrieldezena10/personal-development-index/tree/book/software-engineering-at-google/books/SoftwareEngineeringAtGoogle"> [Book] Software Egineering at Google (O'Reilly)</a> (25%) 
       </summary>
       <ul>


### PR DESCRIPTION
# What was changed

- Added article related to hexagonal architecture to 2023 block of activities;